### PR TITLE
fix: Cypress as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briebug/cypress-schematic",
-  "version": "3.0.3",
+  "version": "3.0.1",
   "description": "Add cypress to an Angular CLI project",
   "builders": "src/builders/builders.json",
   "repository": "briebug/cypress-schematic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@briebug/cypress-schematic",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "description": "Add cypress to an Angular CLI project",
   "builders": "src/builders/builders.json",
   "repository": "briebug/cypress-schematic",
@@ -33,11 +33,13 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "cypress": "^3.6.1"
+  }
   "dependencies": {
     "@angular-devkit/core": "^8.3.15",
     "@angular-devkit/schematics": "^8.3.15",
     "@schematics/angular": "^8.3.15",
-    "cypress": "3.6.1",
     "rxjs": "6.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allows usage of the schematic package in projects that do not match the exact Cypress version

Fixes #18 