### PR TITLE
fix: update support file configuration to support TypeScript

### DIFF
--- a/src/schematics/cypress/files/cypress.json
+++ b/src/schematics/cypress/files/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "supportFile": "cypress/support/index.ts"
+}


### PR DESCRIPTION
The default value for the `supportFile` configuration is `cypress/support/index.js`, and since this schematic uses TypeScript, we must manually specify the TypeScript support file.