### PR TITLE
fix: add missing comma to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "cypress": "^3.6.1"
-  }
+  },
   "dependencies": {
     "@angular-devkit/core": "^8.3.15",
     "@angular-devkit/schematics": "^8.3.15",


### PR DESCRIPTION
The introduction of peer dependencies in this commit (https://github.com/briebug/cypress-schematic/commit/75b55bcb69e759da30f8e2a93fd752692196140a) broke the JSON syntax with a missing comma.