### PR TITLE
🛠 Fix/typescript support 32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ yarn-error.log*
 # Mac OSX Finder files.
 **/.DS_Store
 .DS_Store
+
+# Exclude Cypress Plugin JS files
+!src/schematics/cypress/files/cypress/plugins/*.js

--- a/src/schematics/cypress/files/cypress/integration/spec.ts
+++ b/src/schematics/cypress/files/cypress/integration/spec.ts
@@ -1,4 +1,5 @@
 it("loads examples", () => {
-  cy.visit("http://localhost:4200");
+  const baseUrl: string = "http://localhost:4200";
+  cy.visit(baseUrl);
   cy.contains("Replace me with something relevant");
 });

--- a/src/schematics/cypress/files/cypress/plugins/cy-ts-preprocessor.js
+++ b/src/schematics/cypress/files/cypress/plugins/cy-ts-preprocessor.js
@@ -1,0 +1,26 @@
+const wp = require("@cypress/webpack-preprocessor");
+
+const webpackOptions = {
+  resolve: {
+    extensions: [".ts", ".js"]
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: [/node_modules/],
+        use: [
+          {
+            loader: "ts-loader"
+          }
+        ]
+      }
+    ]
+  }
+};
+
+const options = {
+  webpackOptions
+};
+
+module.exports = wp(options);

--- a/src/schematics/cypress/files/cypress/plugins/cy-ts-preprocessor.js
+++ b/src/schematics/cypress/files/cypress/plugins/cy-ts-preprocessor.js
@@ -1,4 +1,4 @@
-const wp = require("@cypress/webpack-preprocessor");
+const webpackPreprocessor = require("@cypress/webpack-preprocessor");
 
 const webpackOptions = {
   resolve: {
@@ -23,4 +23,4 @@ const options = {
   webpackOptions
 };
 
-module.exports = wp(options);
+module.exports = webpackPreprocessor(options);

--- a/src/schematics/cypress/files/cypress/plugins/index.js
+++ b/src/schematics/cypress/files/cypress/plugins/index.js
@@ -1,0 +1,5 @@
+const cypressTypeScriptPreprocessor = require("./cy-ts-preprocessor");
+
+module.exports = on => {
+  on("file:preprocessor", cypressTypeScriptPreprocessor);
+};

--- a/src/schematics/cypress/files/cypress/tsconfig.json
+++ b/src/schematics/cypress/files/cypress/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["integration/*.ts", "support/*.ts", "../node_modules/cypress"],
-  "compilerOptions": {
-    "types": ["cypress", "node"],
-    "target": "es6"
-  }
+  "include": ["../node_modules/cypress", "*/*.ts"]
 }

--- a/src/schematics/cypress/index_spec.ts
+++ b/src/schematics/cypress/index_spec.ts
@@ -1,5 +1,7 @@
 import { SchematicTestRunner } from "@angular-devkit/schematics/testing";
 
+const NUMBER_OF_SCAFFOLDED_FILES = 37;
+
 describe("@briebug/cypress-schematic", async () => {
   it("works", async () => {
     async function getWorkspaceTree(appName = "bar") {
@@ -37,6 +39,6 @@ describe("@briebug/cypress-schematic", async () => {
     const tree = await runner
       .runSchematicAsync("ng-add", {}, await getWorkspaceTree())
       .toPromise();
-    expect(tree.files.length).toEqual(35);
+    expect(tree.files.length).toEqual(NUMBER_OF_SCAFFOLDED_FILES);
   });
 });


### PR DESCRIPTION
Fixes #32 

# Problem
 Cypress does not fully support TypeScript out-of-the-box (cypress-io/cypress#1859). Currently Cypress accepts `.ts` files and the schematic already sets up everything for the IDE (like VSCode) to work. However, TypeScript itself cannot be used during executing because it is not transpiled by default.

# Solution
Add TypeScript preprocessor like proposed in Cypress docs to the schematic by default (https://docs.cypress.io/guides/tooling/typescript-support.html#Transpiling-TypeScript-test-files).

# Steps taken
Based on the already prepared solution from Gleb @ Cypress (https://github.com/bahmutov/add-typescript-to-cypress):
- Use simpler version of `cypress/tsconfig` (@anthonymjones Not really sure whether we actually need the `types` and `target` like before. As Gleb himself doesn't add them, I suppose we can just remove them)
- Transpile TypeScript files by adding a Cypress plugin by default which uses `@cypress/webpack-preprocessor` (This dependency was already listed by the schematic)
- Set an explicit type in the default `spec.ts` to show everyone that TypeScript *actually* works (not only the `.ts` ending)
- Adjust unit tests to now contain 2 more files which are added by the plugin integration