### PR TITLE
fix(typescript): adjust how custom commands are suggested

### DIFF
--- a/src/schematics/cypress/files/cypress/support/commands.ts
+++ b/src/schematics/cypress/files/cypress/support/commands.ts
@@ -1,4 +1,22 @@
 // ***********************************************
+// This example namespace declaration will help
+// with Intellisense and code completion in your
+// IDE or Text Editor.
+// ***********************************************
+// declare namespace Cypress {
+//   interface Chainable<Subject = any> {
+//     customCommand(param: any): typeof customCommand;
+//   }
+// }
+//
+// function customCommand(param: any): void {
+//   console.warn(param);
+// }
+//
+// NOTE: You can use it like so:
+// Cypress.Commands.add('customCommand', customCommand);
+// 
+// ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
 // existing commands.

--- a/src/schematics/cypress/files/cypress/support/index.ts
+++ b/src/schematics/cypress/files/cypress/support/index.ts
@@ -13,5 +13,5 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
-// When a command from ./commands is ready to use, import with `import * as commands from './commands'` syntax
-// import * as commands from './commands';
+// When a command from ./commands is ready to use, import with `import './commands'` syntax
+// import './commands';


### PR DESCRIPTION
## PREFACE
I'm not an expert, by I'm able to hack my way through things. I could be wrong in some places here, but I just wanted to give back since you guys already put forth so much effort on the schematic. It definitely saved me some time. That is, until I started messing around w/ Custom Commands 😂 

I figured it would be good to submit a PR addressing what I found confusing. Maybe this will help someone else who uses the schematic in the future :)

## The Problem
Typescript + Cypress + Custom Commands sucks. In fact, bahmutov (author of https://github.com/bahmutov/add-typescript-to-cypress) suggests against it outright.
![gitter message](https://i.imgur.com/1eH4tr6.png)
[Read More](https://medium.com/@NicholasBoll/cypress-io-scaling-e2e-testing-with-custom-commands-6b72b902aab)

What ended up confusing me was how `cypress-schematic` suggests you handle custom commands in `support/index.ts`:

```typescript
...
// When a command from ./commands is ready to use, import with `import * as commands from './commands'` syntax
// import * as commands from './commands';
```

Here's a link to a commit in a minimally reproducible repo that shows this didn't work for me:
https://github.com/tabuckner/minimally-reproducible-cypress-typescript-custom-commands/commit/1ddcffa0511908c307de3869535f40894108b093

If you change the syntax of the import statement you're able to suppress one of the two errors:
https://github.com/tabuckner/minimally-reproducible-cypress-typescript-custom-commands/commit/f2e450bc2b08dc2de0efb7cdb0ef2fa96576c240

And finally, to keep typescript/intellisense happy, you can merge (I think that's what's happening anyways) the Cypress namespace with your extended `Chainable` interface:
https://github.com/tabuckner/minimally-reproducible-cypress-typescript-custom-commands/commit/9d17763eba0d6915cd1fed18994155ea45f59bfa

After doing all of this Cypress and Intellisense are happy:
![image](https://user-images.githubusercontent.com/32392635/80103365-bf757f00-8539-11ea-8476-0bce910e4e8d.png)
