### PR TITLE
Check if e2e folder exist before deleting

### DIFF
--- a/src/schematics/cypress/index.ts
+++ b/src/schematics/cypress/index.ts
@@ -107,8 +107,11 @@ function addCypressTestScriptsToPackageJson(): Rule {
 function removeFiles(options: any): Rule {
   return (tree: Tree, context: SchematicContext) => {
     context.logger.debug("Removing e2e directory");
-    tree.delete("./e2e");
-
+   
+    if (tree.exists('./e2e')) {
+      tree.delete('./e2e');
+    }
+    
     if (tree.exists("./angular.json")) {
       const angularJsonVal = getAngularJsonValue(tree);
       const project = getProject(options, angularJsonVal);


### PR DESCRIPTION
If you don't have a e2e folder insider your application, you will get an error.
So test if the folder exist before deleting it.