### PR TITLE
fix: minimum requirement for node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "10"
+    "node": ">=10"
   },
   "contributors": [
     {


### PR DESCRIPTION
v4 requires exactly node 10, so it does not build with more recent version of ndoes like node 12.
This should allow to use the schematics with node 10 and more recent versions, as the CLi does for example https://github.com/angular/angular-cli/blob/master/package.json

For context, here is the current error message when using v4 with node 12:
```
yarn install v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
error @briebug/cypress-schematic@4.0.0: The engine "node" is incompatible with this module. Expected version "10". Got "12.18.3"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```