### PR TITLE
Fix e2e error if no e2e directory is available

### DIFF
--- a/src/schematics/cypress/index.ts
+++ b/src/schematics/cypress/index.ts
@@ -94,11 +94,10 @@ function addCypressTestScriptsToPackageJson(): Rule {
 
 function removeFiles(options: any): Rule {
   return (tree: Tree, context: SchematicContext) => {
-    context.logger.debug('Removing e2e directory');
-
-    if (tree.getDir('./e2e')) {
+    try {
+      context.logger.debug('Removing e2e directory');
       tree.delete('./e2e');
-    }
+    } catch {}
 
     if (tree.exists('./angular.json')) {
       const angularJsonVal = getAngularJsonValue(tree);


### PR DESCRIPTION
If the `./e2e` directory is not available the `tree.getDir`still returns a DirEntry and `tree.exists` only checks the files. There are two ways to solve this issue:
- To check if the e2e is not a file and contains files before deletion. Empty e2e folder will not be deleted and not tracked by git, therefore I prefer the first way.
- Execute tree.delete without if statement within a try-catch statement to handle deletion errors.

The error is described in #30 

> Please add  the new [hacktoberfest-accepted](https://hacktoberfest.digitalocean.com/details#details) label to this PR if you accept the PR.