### PR TITLE
Pass configuration file to cypress

### DIFF
--- a/sandbox-workspace/angular.json
+++ b/sandbox-workspace/angular.json
@@ -173,6 +173,9 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
+            "host": "localhost",
+            "port": 4242,
+            "ssl": true,
             "browserTarget": "second-sandbox:build"
           },
           "configurations": {

--- a/src/builders/cypress/cypress-builder-options.ts
+++ b/src/builders/cypress/cypress-builder-options.ts
@@ -2,7 +2,7 @@ import { JsonObject } from '@angular-devkit/core';
 
 export interface CypressBuilderOptions extends JsonObject {
   baseUrl: string;
-  configPath: string;
+  configFile: string | false;
   browser: 'electron' | 'chrome' | 'chromium' | 'canary' | string;
   devServerTarget: string;
   env: Record<string, string>;

--- a/src/builders/cypress/cypress-builder-options.ts
+++ b/src/builders/cypress/cypress-builder-options.ts
@@ -2,6 +2,7 @@ import { JsonObject } from '@angular-devkit/core';
 
 export interface CypressBuilderOptions extends JsonObject {
   baseUrl: string;
+  configPath: string;
   browser: 'electron' | 'chrome' | 'chromium' | 'canary' | string;
   devServerTarget: string;
   env: Record<string, string>;

--- a/src/builders/cypress/index.ts
+++ b/src/builders/cypress/index.ts
@@ -3,13 +3,13 @@ import {
   BuilderOutput,
   createBuilder,
   scheduleTargetAndForget,
-  targetFromTargetString,
+  targetFromTargetString
 } from '@angular-devkit/architect';
 import { asWindowsPath, experimental, normalize } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import * as os from 'os';
 import { dirname, join } from 'path';
-import { run, open } from 'cypress';
+import { open, run } from 'cypress';
 
 import { from, noop, Observable, of } from 'rxjs';
 import { catchError, concatMap, first, map, switchMap, tap } from 'rxjs/operators';
@@ -27,7 +27,6 @@ function runCypress(
   if (options.tsConfig) {
     options.env.tsConfig = join(context.workspaceRoot, options.tsConfig);
   }
-
   const workspace = new experimental.workspace.Workspace(
     normalize(context.workspaceRoot),
     new NodeJsSyncHost()
@@ -39,11 +38,12 @@ function runCypress(
     map((workspaceRoot) => ({
       ...options,
       projectPath: `${workspaceRoot}/cypress`,
+      config: options.configPath ? require(`${workspaceRoot}/${options.configPath}`) : undefined
     })),
     switchMap((options) =>
       (!!options.devServerTarget
-        ? startDevServer(options.devServerTarget, options.watch, context)
-        : of(options.baseUrl)
+          ? startDevServer(options.devServerTarget, options.watch, context)
+          : of(options.baseUrl)
       ).pipe(
         concatMap((baseUrl: string) => initCypress({ ...options, baseUrl })),
         options.watch ? tap(noop) : first(),
@@ -69,13 +69,13 @@ function initCypress(userOptions: CypressBuilderOptions): Observable<BuilderOutp
     exit: true,
     headless: true,
     record: false,
-    spec: '',
+    spec: ''
   };
 
   const options: any = {
     ...defaultOptions,
     ...userOptions,
-    headed: !userOptions.headless,
+    headed: !userOptions.headless
   };
 
   const { watch, headless } = userOptions;
@@ -91,7 +91,7 @@ export function startDevServer(
   context: BuilderContext
 ): Observable<string> {
   const overrides = {
-    watch,
+    watch
   };
   return scheduleTargetAndForget(context, targetFromTargetString(devServerTarget), overrides).pipe(
     map((output: any) => {

--- a/src/builders/cypress/index.ts
+++ b/src/builders/cypress/index.ts
@@ -3,7 +3,7 @@ import {
   BuilderOutput,
   createBuilder,
   scheduleTargetAndForget,
-  targetFromTargetString
+  targetFromTargetString,
 } from '@angular-devkit/architect';
 import { asWindowsPath, experimental, normalize } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
@@ -38,12 +38,11 @@ function runCypress(
     map((workspaceRoot) => ({
       ...options,
       projectPath: `${workspaceRoot}/cypress`,
-      config: options.configPath ? require(`${workspaceRoot}/${options.configPath}`) : undefined
     })),
     switchMap((options) =>
       (!!options.devServerTarget
-          ? startDevServer(options.devServerTarget, options.watch, context)
-          : of(options.baseUrl)
+        ? startDevServer(options.devServerTarget, options.watch, context)
+        : of(options.baseUrl)
       ).pipe(
         concatMap((baseUrl: string) => initCypress({ ...options, baseUrl })),
         options.watch ? tap(noop) : first(),
@@ -64,19 +63,22 @@ function initCypress(userOptions: CypressBuilderOptions): Observable<BuilderOutp
   const defaultOptions = {
     project: projectFolderPath,
     browser: 'electron',
-    config: {},
     env: null,
     exit: true,
     headless: true,
     record: false,
-    spec: ''
+    spec: '',
   };
 
   const options: any = {
     ...defaultOptions,
     ...userOptions,
-    headed: !userOptions.headless
+    headed: !userOptions.headless,
   };
+
+  if (userOptions.configFile === undefined) {
+    options.config = {};
+  }
 
   const { watch, headless } = userOptions;
 
@@ -91,7 +93,7 @@ export function startDevServer(
   context: BuilderContext
 ): Observable<string> {
   const overrides = {
-    watch
+    watch,
   };
   return scheduleTargetAndForget(context, targetFromTargetString(devServerTarget), overrides).pipe(
     map((output: any) => {

--- a/src/builders/cypress/schema.json
+++ b/src/builders/cypress/schema.json
@@ -7,9 +7,9 @@
       "type": "string",
       "description": "Use this to pass directly the address of your distant server address with the port running your application"
     },
-    "configPath": {
-      "type": "string",
-      "description": "The path to the cypress configuration that should be used."
+    "configFile": {
+      "type": ["string", "boolean"],
+      "description": "You can specify a path to a JSON file where configuration values are set or you can pass false to disable the use of a configuration file entirely."
     },
     "browser": {
       "type": "string",

--- a/src/builders/cypress/schema.json
+++ b/src/builders/cypress/schema.json
@@ -7,6 +7,10 @@
       "type": "string",
       "description": "Use this to pass directly the address of your distant server address with the port running your application"
     },
+    "configPath": {
+      "type": "string",
+      "description": "The path to the cypress configuration that should be used."
+    },
     "browser": {
       "type": "string",
       "description": "The browser to run tests in.",

--- a/src/schematics/cypress/files/cypress.json
+++ b/src/schematics/cypress/files/cypress.json
@@ -1,3 +1,5 @@
 {
-  "supportFile": "cypress/support/index.ts"
+  "integrationFolder": "<%= root%>cypress/integration",
+  "supportFile": "<%= root%>cypress/support/index.ts",
+  "baseUrl": "<%= baseUrl%>"
 }

--- a/src/schematics/cypress/files/cypress/integration/spec.ts
+++ b/src/schematics/cypress/files/cypress/integration/spec.ts
@@ -1,5 +1,4 @@
-it("loads examples", () => {
-  const baseUrl: string = "http://localhost:4200";
-  cy.visit(baseUrl);
-  cy.contains("Replace me with something relevant");
+it('loads examples', () => {
+  cy.visit('/');
+  cy.contains('Replace me with something relevant');
 });

--- a/src/schematics/cypress/files/cypress/support/commands.ts
+++ b/src/schematics/cypress/files/cypress/support/commands.ts
@@ -15,7 +15,7 @@
 //
 // NOTE: You can use it like so:
 // Cypress.Commands.add('customCommand', customCommand);
-// 
+//
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/src/schematics/cypress/files/cypress/tsconfig.json
+++ b/src/schematics/cypress/files/cypress/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "extends": "../tsconfig.json",
-  "include": ["../node_modules/cypress", "**/*.ts"]
+  "extends": "<%= relativeToWorkspace %>/tsconfig.json",
+  "include": ["<%= relativeToWorkspace %>/node_modules/cypress", "**/*.ts"],
+  "compilerOptions": {
+    "sourceMap": false
+  }
 }

--- a/src/schematics/cypress/index.ts
+++ b/src/schematics/cypress/index.ts
@@ -265,10 +265,15 @@ function modifyAngularJson(options: any): Rule {
   };
 }
 
-export const addCypressTsConfig = (tree: Tree, angularJsonVal: any, project: string) => {
-  const tsConfig = angularJsonVal.projects[project]?.architect?.lint?.options?.tsConfig;
+export const addCypressTsConfig = (tree: Tree, angularJsonVal: any, projectName: string) => {
+  const project = angularJsonVal.projects[projectName];
+  const tsConfig = project?.architect?.lint?.options?.tsConfig;
   if (tsConfig) {
-    tsConfig.push('cypress/tsconfig.json');
+    let prefix = '';
+    if (project.root) {
+      prefix = `${project.root}/`;
+    }
+    tsConfig.push(`${prefix}cypress/tsconfig.json`);
   }
   return tree.overwrite('./angular.json', JSON.stringify(angularJsonVal, null, 2));
 };

--- a/src/schematics/cypress/index.ts
+++ b/src/schematics/cypress/index.ts
@@ -266,30 +266,31 @@ function modifyAngularJson(options: any): Rule {
 }
 
 export const addCypressTsConfig = (tree: Tree, angularJsonVal: any, project: string) => {
-  const projectLintOptionsJson =
-    angularJsonVal['projects'][project]['architect']['lint']['options'];
-
-  projectLintOptionsJson['tsConfig'].push('cypress/tsconfig.json');
-
+  const tsConfig = angularJsonVal.projects[project]?.architect?.lint?.options?.tsConfig;
+  if (tsConfig) {
+    tsConfig.push('cypress/tsconfig.json');
+  }
   return tree.overwrite('./angular.json', JSON.stringify(angularJsonVal, null, 2));
 };
 
 export const removeE2ELinting = (tree: Tree, angularJsonVal: any, project: string) => {
-  let projectLintOptionsJson = angularJsonVal['projects'][project]['architect']['lint']['options'];
-  let filteredTsConfigPaths;
+  const projectLintOptionsJson = angularJsonVal.projects[project]?.architect?.lint?.options;
+  if (projectLintOptionsJson) {
+    let filteredTsConfigPaths;
 
-  if (Array.isArray(projectLintOptionsJson['tsConfig'])) {
-    filteredTsConfigPaths = projectLintOptionsJson['tsConfig'].filter((path: string) => {
-      const pathIncludesE2e = path.includes('e2e');
-      return !pathIncludesE2e && path;
-    });
-  } else {
-    filteredTsConfigPaths = !projectLintOptionsJson['tsConfig'].includes('e2e')
-      ? projectLintOptionsJson['tsConfig']
-      : '';
+    if (Array.isArray(projectLintOptionsJson['tsConfig'])) {
+      filteredTsConfigPaths = projectLintOptionsJson?.tsConfig?.filter((path: string) => {
+        const pathIncludesE2e = path.includes('e2e');
+        return !pathIncludesE2e && path;
+      });
+    } else {
+      filteredTsConfigPaths = !projectLintOptionsJson?.tsConfig?.includes('e2e')
+        ? projectLintOptionsJson?.tsConfig
+        : '';
+    }
+
+    projectLintOptionsJson['tsConfig'] = filteredTsConfigPaths;
   }
-
-  projectLintOptionsJson['tsConfig'] = filteredTsConfigPaths;
 
   return tree.overwrite('./angular.json', JSON.stringify(angularJsonVal, null, 2));
 };


### PR DESCRIPTION
Issue: #67 

## What I did
- I added configFile to the options list of the builder to pass the configuration (or false) to cypress. 
- Changed schematics to create a cypress directory for each workspace project.
- Disabled source maps in cypress/tsconfig.json to avoid the same error: https://github.com/cypress-io/cypress/issues/8477
- Validate angular.json structure before updating (06b57b9)
## How to test?
`npm run test && npm run test:ws`


## TODOs
- [x] Extend options list
- [x] Create cypress folder for each project 
- [x] Fix lint path update in angular.json

> Please add  the new [hacktoberfest-accepted](https://hacktoberfest.digitalocean.com/details#details) label to this PR if you accept the PR.