### PR TITLE
Add additional default configuration

### DIFF
--- a/src/schematics/cypress/files/cypress.json
+++ b/src/schematics/cypress/files/cypress.json
@@ -1,5 +1,9 @@
 {
   "integrationFolder": "<%= root%>cypress/integration",
   "supportFile": "<%= root%>cypress/support/index.ts",
+  "videosFolder": "<%= root%>cypress/videos",
+  "screenshotsFolder": "<%= root%>cypress/screenshots",
+  "pluginsFile": "<%= root%>cypress/plugins/index.js",
+  "fixturesFolder": "<%= root%>cypress/fixtures",
   "baseUrl": "<%= baseUrl%>"
 }


### PR DESCRIPTION
I added additional default configuration to cypress.json to avoid project-based folders like video, screenshots and fixture on the root level. 