### PR TITLE
fix: use cypress types in generated tsconfig

### DIFF
--- a/src/schematics/cypress/files/cypress/tsconfig.json
+++ b/src/schematics/cypress/files/cypress/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "<%= relativeToWorkspace %>/tsconfig.json",
-  "include": ["<%= relativeToWorkspace %>/node_modules/cypress", "**/*.ts"],
+  "include": ["**/*.ts"],
   "compilerOptions": {
-    "sourceMap": false
+    "sourceMap": false,
+    "types": ["cypress"]
   }
 }


### PR DESCRIPTION
On top of #95 to make sure nothing breaks.

I think this is a cleaner way to reference the cypress types