### PR TITLE
fix(schematics): use JSON schema draft-07 

### DIFF
--- a/src/schematics/cypress/schema.json
+++ b/src/schematics/cypress/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "BriebugSchematicsCypress",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "BriebugSchematicsCypress",
   "title": "Cypress Install Schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Angular CLI v12 now only supports JSON schema draft-07, meaning `id` needs to be renamed `$id`.
See https://github.com/angular/angular-cli/pull/20482 for more details.

Using the current schematics currently warns:

   "BriebugSchematicsCypress" schema is using the keyword "id" which its support is deprecated. Use "$id" for schema ID.

This commit updates the schema according to the breaking change.